### PR TITLE
feat: add ppc64le architecture support to llama-stack-distribution builds

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -5,6 +5,7 @@ ARG BASE_IMAGE
 ARG LLAMA_STACK_VERSION
 ARG WHEEL_RELEASE_AARCH64
 ARG WHEEL_RELEASE_X86_64
+ARG WHEEL_RELEASE_PPC64LE
 ARG WHEEL_RELEASE_PACKAGE
 ARG WHEEL_RELEASE_PROJECT_ID
 
@@ -18,7 +19,7 @@ LABEL com.redhat.component="llama-stack-cpu-rhel9-container" \
       io.openshift.expose-services="" \
       com.redhat.license_terms="https://www.redhat.com/en/about/eulas#RHAIIS" \
       com.redhat.aiplatform.image="${BASE_IMAGE}" \
-      com.redhat.aiplatform.wheel_release="${WHEEL_RELEASE_AARCH64} ${WHEEL_RELEASE_X86_64}"
+      com.redhat.aiplatform.wheel_release="${WHEEL_RELEASE_AARCH64} ${WHEEL_RELEASE_X86_64} ${WHEEL_RELEASE_PPC64LE}"
 
 RUN --mount=type=secret,id=rhel-ai-private-index-auth/BOT_PAT,target=/run/secrets/gitlab_pat,required=true,uid=${CNB_USER_ID},gid=${CNB_GROUP_ID} \
     ${APP_ROOT}/lib/tools/install-wheel-release.sh

--- a/konflux/cpu-ubi9.conf
+++ b/konflux/cpu-ubi9.conf
@@ -4,3 +4,4 @@ WHEEL_RELEASE_PROJECT_ID=71275045
 WHEEL_RELEASE_PACKAGE=llama-stack-wheels
 WHEEL_RELEASE_AARCH64=3.4.1341+llama-stack-cpu-ubi9-aarch64
 WHEEL_RELEASE_X86_64=3.4.1341+llama-stack-cpu-ubi9-x86_64
+WHEEL_RELEASE_PPC64LE=3.4.1341+llama-stack-cpu-ubi9-ppc64le


### PR DESCRIPTION
# What does this PR do?
Adds support for ppc64le (Power) architecture in llama-stack-distribution CPU builds.
Also update the wheels package registry from 3.4-EA2 to 3.4