### PR TITLE
chore: update base image to 3.3.1-1775671404

### DIFF
--- a/konflux/cpu-ubi9.conf
+++ b/konflux/cpu-ubi9.conf
@@ -1,4 +1,4 @@
-BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.0-1757673655
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.3.1-1775671404
 LLAMA_STACK_VERSION=0.0
 WHEEL_RELEASE_PROJECT_ID=71275045
 WHEEL_RELEASE_PACKAGE=llama-stack-wheels


### PR DESCRIPTION
Update BASE_IMAGE from quay.io/aipcc/base-images/cpu:3.0-1757673655 to 3.3.1-1775671404 to pick up updated system RPMs including libprotobuf v25.

# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
