### PR TITLE
Add ppc64le wheel support for Konflux builds

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -5,6 +5,7 @@ ARG BASE_IMAGE
 ARG LLAMA_STACK_VERSION
 ARG WHEEL_RELEASE_AARCH64
 ARG WHEEL_RELEASE_X86_64
+ARG WHEEL_RELEASE_PPC64LE
 ARG WHEEL_RELEASE_PACKAGE
 ARG WHEEL_RELEASE_PROJECT_ID
 
@@ -18,7 +19,7 @@ LABEL com.redhat.component="llama-stack-cpu-rhel9-container" \
       io.openshift.expose-services="" \
       com.redhat.license_terms="https://www.redhat.com/en/about/eulas#RHAIIS" \
       com.redhat.aiplatform.image="${BASE_IMAGE}" \
-      com.redhat.aiplatform.wheel_release="${WHEEL_RELEASE_AARCH64} ${WHEEL_RELEASE_X86_64}"
+      com.redhat.aiplatform.wheel_release="${WHEEL_RELEASE_AARCH64} ${WHEEL_RELEASE_X86_64} ${WHEEL_RELEASE_PPC64LE}"
 
 RUN --mount=type=secret,id=rhel-ai-private-index-auth/BOT_PAT,target=/run/secrets/gitlab_pat,required=true,uid=${CNB_USER_ID},gid=${CNB_GROUP_ID} \
     ${APP_ROOT}/lib/tools/install-wheel-release.sh

--- a/konflux/cpu-ubi9.conf
+++ b/konflux/cpu-ubi9.conf
@@ -4,3 +4,4 @@ WHEEL_RELEASE_PROJECT_ID=71275045
 WHEEL_RELEASE_PACKAGE=llama-stack-wheels
 WHEEL_RELEASE_AARCH64=3.4.1341+llama-stack-cpu-ubi9-aarch64
 WHEEL_RELEASE_X86_64=3.4.1341+llama-stack-cpu-ubi9-x86_64
+WHEEL_RELEASE_PPC64LE=3.4.1341+llama-stack-cpu-ubi9-ppc64le

--- a/konflux/cpu-ubi9.conf
+++ b/konflux/cpu-ubi9.conf
@@ -2,5 +2,5 @@ BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.0-1757673655
 LLAMA_STACK_VERSION=0.0
 WHEEL_RELEASE_PROJECT_ID=71275045
 WHEEL_RELEASE_PACKAGE=llama-stack-wheels
-WHEEL_RELEASE_AARCH64=3.4-EA2.1236+llama-stack-cpu-ubi9-aarch64
-WHEEL_RELEASE_X86_64=3.4-EA2.1236+llama-stack-cpu-ubi9-x86_64
+WHEEL_RELEASE_AARCH64=3.4.1341+llama-stack-cpu-ubi9-aarch64
+WHEEL_RELEASE_X86_64=3.4.1341+llama-stack-cpu-ubi9-x86_64


### PR DESCRIPTION
# What does this PR do?
Add WHEEL_RELEASE_PPC64LE ARG to Dockerfile.konflux and cpu-ubi9.conf to support ppc64le architecture in Konflux builds.

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
