### PR TITLE
chore: Add ppc64le wheel support for Konflux builds

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -5,6 +5,7 @@ ARG BASE_IMAGE
 ARG LLAMA_STACK_VERSION
 ARG WHEEL_RELEASE_AARCH64
 ARG WHEEL_RELEASE_X86_64
+ARG WHEEL_RELEASE_PPC64LE
 ARG WHEEL_RELEASE_PACKAGE
 ARG WHEEL_RELEASE_PROJECT_ID
 
@@ -18,7 +19,7 @@ LABEL com.redhat.component="llama-stack-cpu-rhel9-container" \
       io.openshift.expose-services="" \
       com.redhat.license_terms="https://www.redhat.com/en/about/eulas#RHAIIS" \
       com.redhat.aiplatform.image="${BASE_IMAGE}" \
-      com.redhat.aiplatform.wheel_release="${WHEEL_RELEASE_AARCH64} ${WHEEL_RELEASE_X86_64}"
+      com.redhat.aiplatform.wheel_release="${WHEEL_RELEASE_AARCH64} ${WHEEL_RELEASE_X86_64} ${WHEEL_RELEASE_PPC64LE}"
 
 RUN --mount=type=secret,id=rhel-ai-private-index-auth/BOT_PAT,target=/run/secrets/gitlab_pat,required=true,uid=${CNB_USER_ID},gid=${CNB_GROUP_ID} \
     ${APP_ROOT}/lib/tools/install-wheel-release.sh

--- a/konflux/cpu-ubi9.conf
+++ b/konflux/cpu-ubi9.conf
@@ -4,3 +4,4 @@ WHEEL_RELEASE_PROJECT_ID=71275045
 WHEEL_RELEASE_PACKAGE=llama-stack-wheels
 WHEEL_RELEASE_AARCH64=3.4.1341+llama-stack-cpu-ubi9-aarch64
 WHEEL_RELEASE_X86_64=3.4.1341+llama-stack-cpu-ubi9-x86_64
+WHEEL_RELEASE_PPC64LE=3.4.1341+llama-stack-cpu-ubi9-ppc64le


### PR DESCRIPTION
Add WHEEL_RELEASE_PPC64LE ARG to Dockerfile.konflux and cpu-ubi9.conf to support ppc64le architecture in Konflux builds.

# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
