### PR TITLE
fix: remove eval/scoring/benchmark from distribution config

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -25,7 +25,6 @@ RUN uv pip install \
     'pypdf>=6.7.2' \
     aiosqlite \
     asyncpg \
-    autoevals \
     boto3 \
     chardet \
     einops \
@@ -55,15 +54,7 @@ RUN uv pip install \
     transformers \
     uvicorn
 RUN uv pip install \
-    llama_stack_provider_lmeval==0.5.0
-RUN uv pip install \
-    llama_stack_provider_ragas[inline]==0.6.1
-RUN uv pip install \
-    llama_stack_provider_ragas[remote]==0.6.1
-RUN uv pip install \
     llama_stack_provider_trustyai_fms==0.4.0
-RUN uv pip install \
-    llama_stack_provider_trustyai_garak==0.3.1
 RUN uv pip install --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision
 RUN uv pip install --no-deps sentence-transformers
 RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.7.1+rhaiv.1

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -13,10 +13,6 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | batches | inline::reference | No | ✅ | N/A |
 | datasetio | inline::localfs | No | ✅ | N/A |
 | datasetio | remote::huggingface | No | ✅ | N/A |
-| eval | inline::trustyai_ragas | Yes (version 0.6.1) | ❌ | Set the `TRUSTYAI_EMBEDDING_MODEL` environment variable |
-| eval | remote::trustyai_garak | Yes (version 0.3.1) | ❌ | Set the `ENABLE_KUBEFLOW_GARAK` environment variable |
-| eval | remote::trustyai_lmeval | Yes (version 0.5.0) | ✅ | N/A |
-| eval | remote::trustyai_ragas | Yes (version 0.6.1) | ❌ | Set the `ENABLE_KUBEFLOW_RAGAS` environment variable |
 | files | inline::localfs | No | ✅ | N/A |
 | files | remote::s3 | No | ❌ | Set the `ENABLE_S3` environment variable |
 | inference | inline::sentence-transformers | No | ❌ | Set the `ENABLE_SENTENCE_TRANSFORMERS` environment variable |
@@ -30,9 +26,6 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | responses | inline::builtin | No | ✅ | N/A |
 | safety | remote::passthrough | No | ❌ | Set the `PASSTHROUGH_SAFETY_URL` environment variable |
 | safety | remote::trustyai_fms | Yes (version 0.4.0) | ✅ | N/A |
-| scoring | inline::basic | No | ✅ | N/A |
-| scoring | inline::braintrust | No | ✅ | N/A |
-| scoring | inline::llm-as-judge | No | ✅ | N/A |
 | tool_runtime | inline::file-search | No | ✅ | N/A |
 | tool_runtime | remote::brave-search | No | ✅ | N/A |
 | tool_runtime | remote::model-context-protocol | No | ✅ | N/A |

--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -4,10 +4,8 @@ apis:
 - responses
 - batches
 - datasetio
-- eval
 - inference
 - safety
-- scoring
 - tool_runtime
 - vector_io
 - files
@@ -147,44 +145,6 @@ providers:
           table_name: agents_responses
           max_write_queue_size: 10000
           num_writers: 4
-  eval:
-  - provider_id: trustyai_lmeval
-    provider_type: remote::trustyai_lmeval
-    module: llama_stack_provider_lmeval==0.5.0
-    config:
-      use_k8s: ${env.TRUSTYAI_LMEVAL_USE_K8S:=true}
-      base_url: ${env.VLLM_URL:=http://localhost:8000/v1}
-  - provider_id: ${env.TRUSTYAI_EMBEDDING_MODEL:+trustyai_ragas_inline}
-    provider_type: inline::trustyai_ragas
-    module: llama_stack_provider_ragas.inline==0.6.1
-    config:
-      embedding_model: ${env.TRUSTYAI_EMBEDDING_MODEL:=}
-  - provider_id: ${env.ENABLE_KUBEFLOW_RAGAS:+trustyai_ragas_remote}
-    provider_type: remote::trustyai_ragas
-    module: llama_stack_provider_ragas.remote==0.6.1
-    config:
-      embedding_model: ${env.TRUSTYAI_EMBEDDING_MODEL:=}
-      kubeflow_config:
-        results_s3_prefix: ${env.KUBEFLOW_RESULTS_S3_PREFIX:=}
-        results_s3_endpoint: ${env.KUBEFLOW_RESULTS_S3_ENDPOINT:=https://s3.us-east-1.amazonaws.com}
-        results_s3_path_style: ${env.KUBEFLOW_RESULTS_S3_PATH_STYLE:=false}
-        s3_credentials_secret_name: ${env.KUBEFLOW_S3_CREDENTIALS_SECRET_NAME:=}
-        pipelines_endpoint: ${env.KUBEFLOW_PIPELINES_ENDPOINT:=}
-        namespace: ${env.KUBEFLOW_NAMESPACE:=}
-        llama_stack_url: ${env.KUBEFLOW_LLAMA_STACK_URL:=}
-        base_image: ${env.KUBEFLOW_BASE_IMAGE:=}
-        pipelines_api_token: ${env.KUBEFLOW_PIPELINES_TOKEN:=}
-  - provider_id: ${env.ENABLE_KUBEFLOW_GARAK:+trustyai_garak_remote}
-    provider_type: remote::trustyai_garak
-    module: llama_stack_provider_trustyai_garak==0.3.1
-    config:
-      llama_stack_url: ${env.KUBEFLOW_LLAMA_STACK_URL:=}
-      kubeflow_config:
-        pipelines_endpoint: ${env.KUBEFLOW_PIPELINES_ENDPOINT:=}
-        namespace: ${env.KUBEFLOW_NAMESPACE:=}
-        garak_base_image: ${env.KUBEFLOW_GARAK_BASE_IMAGE:=}
-        pipelines_api_token: ${env.KUBEFLOW_PIPELINES_TOKEN:=}
-        experiment_name: ${env.KUBEFLOW_EXPERIMENT_NAME:=}
   datasetio:
   - provider_id: huggingface
     provider_type: remote::huggingface
@@ -198,17 +158,6 @@ providers:
       kvstore:
         backend: kv_default
         namespace: datasetio::localfs
-  scoring:
-  - provider_id: basic
-    provider_type: inline::basic
-    config: {}
-  - provider_id: llm-as-judge
-    provider_type: inline::llm-as-judge
-    config: {}
-  - provider_id: braintrust
-    provider_type: inline::braintrust
-    config:
-      openai_api_key: ${env.OPENAI_API_KEY:=}
   tool_runtime:
   - provider_id: brave-search
     provider_type: remote::brave-search
@@ -296,62 +245,6 @@ registered_resources:
   shields: []
   vector_dbs: []
   datasets: []
-  scoring_fns: []
-  benchmarks:
-  - benchmark_id: ${env.ENABLE_KUBEFLOW_GARAK:+trustyai_garak::owasp_llm_top10}
-    dataset_id: garak
-    scoring_functions:
-      - garak_scoring
-    provider_id: trustyai_garak_remote
-    provider_benchmark_id: owasp_llm_top10
-  - benchmark_id: ${env.ENABLE_KUBEFLOW_GARAK:+trustyai_garak::avid_security}
-    dataset_id: garak
-    scoring_functions:
-      - garak_scoring
-    provider_id: trustyai_garak_remote
-    provider_benchmark_id: avid_security
-  - benchmark_id: ${env.ENABLE_KUBEFLOW_GARAK:+trustyai_garak::avid_ethics}
-    dataset_id: garak
-    scoring_functions:
-      - garak_scoring
-    provider_id: trustyai_garak_remote
-    provider_benchmark_id: avid_ethics
-  - benchmark_id: ${env.ENABLE_KUBEFLOW_GARAK:+trustyai_garak::avid_performance}
-    dataset_id: garak
-    scoring_functions:
-      - garak_scoring
-    provider_id: trustyai_garak_remote
-    provider_benchmark_id: avid_performance
-  - benchmark_id: ${env.ENABLE_KUBEFLOW_GARAK:+trustyai_garak::quick}
-    dataset_id: garak
-    scoring_functions:
-      - garak_scoring
-    provider_id: trustyai_garak_remote
-    provider_benchmark_id: quick
-  - benchmark_id: ${env.ENABLE_KUBEFLOW_GARAK:+trustyai_garak::avid}
-    dataset_id: garak
-    scoring_functions:
-      - garak_scoring
-    provider_id: trustyai_garak_remote
-    provider_benchmark_id: trustyai_garak::avid
-  - benchmark_id: ${env.ENABLE_KUBEFLOW_GARAK:+trustyai_garak::quality}
-    dataset_id: garak
-    scoring_functions:
-      - garak_scoring
-    provider_id: trustyai_garak_remote
-    provider_benchmark_id: trustyai_garak::quality
-  - benchmark_id: ${env.ENABLE_KUBEFLOW_GARAK:+trustyai_garak::cwe}
-    dataset_id: garak
-    scoring_functions:
-      - garak_scoring
-    provider_id: trustyai_garak_remote
-    provider_benchmark_id: trustyai_garak::cwe
-  - benchmark_id: ${env.ENABLE_KUBEFLOW_GARAK:+trustyai_garak::intents}
-    dataset_id: garak
-    scoring_functions:
-      - garak_scoring
-    provider_id: trustyai_garak_remote
-    provider_benchmark_id: trustyai_garak::intents
   tool_groups:
   - toolgroup_id: builtin::websearch
     provider_id: tavily-search

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -19,7 +19,6 @@ function start_and_wait_for_llama_stack_container {
     --env "EMBEDDING_MODEL=$EMBEDDING_MODEL"
     --env "VLLM_URL=$VLLM_URL"
     --env "VLLM_EMBEDDING_URL=$VLLM_EMBEDDING_URL"
-    --env "TRUSTYAI_LMEVAL_USE_K8S=False"
     --env "POSTGRES_HOST=${POSTGRES_HOST:-localhost}"
     --env "POSTGRES_PORT=${POSTGRES_PORT:-5432}"
     --env "POSTGRES_DB=${POSTGRES_DB:-llamastack}"


### PR DESCRIPTION
# What does this PR do?

Remove eval and scoring APIs, trustyai_lmeval/ragas/garak providers, all benchmark registrations, autoevals package, and related test env vars from the RHDS distribution. Evaluation moves to MLflow and Eval Hub as platform-level concerns.

Files changed:
- `distribution/config.yaml` — removed eval/scoring API declarations, 4 eval providers (lmeval, ragas inline+remote, garak), scoring providers (basic, llm-as-judge, braintrust), 9 garak benchmark registrations
- `distribution/Containerfile` — removed autoevals, llama_stack_provider_lmeval, llama_stack_provider_ragas, llama_stack_provider_trustyai_garak packages. Kept llama_stack_provider_trustyai_fms (safety, not eval)
- `distribution/README.md` — removed 7 eval/scoring provider rows from the API table
- `tests/smoke.sh` — removed TRUSTYAI_LMEVAL_USE_K8S env var

Closes RHAIENG-4449

Related: Pipeline [MR 402](https://gitlab.com/redhat/rhel-ai/llama-stack/pipeline/-/merge_requests/402) (same eval removal for GitLab pipeline repo) was merged.

## Test Plan

This is a config-only change (removal of eval surface). No functional code modified.

1. Verified no eval/scoring/benchmark references remain in config.yaml
2. Verified trustyai_fms (safety provider) is preserved in Containerfile
3. Verified README table only contains non-eval providers
