### PR TITLE
fix: bump wheel release tags for starlette CVE-2026-48710 fix

### DIFF
--- a/konflux/cpu-ubi9.conf
+++ b/konflux/cpu-ubi9.conf
@@ -2,5 +2,5 @@ BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.0-1757673655
 LLAMA_STACK_VERSION=0.0
 WHEEL_RELEASE_PROJECT_ID=71275045
 WHEEL_RELEASE_PACKAGE=llama-stack-wheels
-WHEEL_RELEASE_AARCH64=3.3.932+llama-stack-cpu-ubi9-aarch64
-WHEEL_RELEASE_X86_64=3.3.932+llama-stack-cpu-ubi9-x86_64
+WHEEL_RELEASE_AARCH64=3.3.1553+llama-stack-cpu-ubi9-aarch64
+WHEEL_RELEASE_X86_64=3.3.1553+llama-stack-cpu-ubi9-x86_64


### PR DESCRIPTION
## Summary
- Updates wheel release tags from 3.3.932 to 3.3.1553
- New wheels include starlette>=1.0.1 constraint (CVE-2026-48710) and fastapi>=0.133.0

## Test plan
- [ ] Konflux build passes