### PR TITLE
chore: update ogx to v1.1.0+rhaiv.0 for 3.5-ea.2

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -51,7 +51,4 @@ ENV TIKTOKEN_CACHE_DIR="${HOME}/.cache/tiktoken"
 COPY distribution/config.yaml ${APP_ROOT}/config.yaml
 COPY --chmod=755 distribution/entrypoint.sh ${APP_ROOT}/entrypoint.sh
 
-# Download embedding model
-RUN hf download ibm-granite/granite-embedding-125m-english
-
 ENTRYPOINT [ "/opt/app-root/entrypoint.sh" ]

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -22,12 +22,6 @@ RUN uv pip install \
     'torchvision; platform_machine == "ppc64le"' \
     'torchao>=0.12.0; platform_machine == "ppc64le"'
 
-COPY distribution/versions.env ${APP_ROOT}/versions.env
-# TODO: remove --extra-index-url once ogx packages are in the base image index
-RUN . ${APP_ROOT}/versions.env && \
-    uv pip install --extra-index-url https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9-test/simple \
-        ogx==${OGX_VERSION} ogx-api==${OGX_VERSION} ogx-client==${OGX_CLIENT_VERSION}
-
 # Install milvus-lite for ppc64le
 RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
         pip install milvus-lite==2.5.1  --index-url https://wheels.developerfirst.ibm.com/ppc64le/linux/+simple/  && \
@@ -37,6 +31,10 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
         mv /opt/app-root/lib64/python3.12/site-packages/milvus_lite/lib/libgcc_s.so.1 \
            /opt/app-root/lib64/python3.12/site-packages/milvus_lite/lib/libgcc_s.so.1.disabled; \
     fi
+COPY distribution/constraints.txt ${APP_ROOT}/constraints.txt
+COPY distribution/requirements.txt ${APP_ROOT}/requirements.txt
+RUN uv pip install https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9-test/models_dev-1.0.398-2-py3-none-any.whl \
+    && uv pip install --constraint ${APP_ROOT}/constraints.txt -r ${APP_ROOT}/requirements.txt
 
 USER 0
 # install missing RPMs (online, requires subscription)

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -15,12 +15,6 @@ LABEL com.redhat.component="ogx-cpu-rhel9-container" \
       com.redhat.license_terms="https://www.redhat.com/en/about/eulas#RHAIIS" \
       com.redhat.aiplatform.image="${BASE_IMAGE}"
 
-COPY --chmod=755 distribution/install-deps.sh ${APP_ROOT}/install-deps.sh
-RUN ${APP_ROOT}/install-deps.sh
-RUN uv pip install \
-    'torch; platform_machine == "ppc64le"' \
-    'torchvision; platform_machine == "ppc64le"' \
-    'torchao>=0.12.0; platform_machine == "ppc64le"'
 
 # Install milvus-lite for ppc64le
 RUN if [ "$TARGETARCH" = "ppc64le" ]; then \

--- a/konflux/cpu-ubi9.conf
+++ b/konflux/cpu-ubi9.conf
@@ -1,2 +1,2 @@
-BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.1
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.5.0-ea.2
 OGX_VERSION=0.0


### PR DESCRIPTION
## Summary
- Bump OGX to v1.1.0+rhaiv.0 (upstream v1.1.0)
- Update base image to EA2 (`quay.io/aipcc/base-images/cpu:3.5.0-ea.2`)
- Add kvstore config to messages provider (required by upstream)
- Remove torch/torchvision ppc64le workaround from Dockerfile
- Remove `hf download ibm-granite/granite-embedding-125m-english` from Dockerfile
- Remove install-deps.sh and versions.env install steps, use constraints+requirements instead
- Drop pymilvus/setuptools constraints (milvus-lite 3.x is pure Python)
- Update pinned deps: milvus-lite>=3.0.0, pymilvus!=2.6.10
- Fix pre-commit in release workflow (use pre-commit/action)
- Drop psycopg2-binary (pgvector migrated to asyncpg upstream)
- Add pgvector>=0.3.0, opentelemetry-exporter-otlp-proto-grpc

## Test plan
- [ ] Konflux build succeeds for all arches (x86_64, arm64, ppc64le)
- [ ] Image starts with postgres backend
- [ ] Showroom demos pass