### PR TITLE
fix: add azure_ai_contentunderstanding wheel to Dockerfile.konflux

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -27,7 +27,7 @@ LABEL com.ogx.config.config.yaml="IyBUaGlzIGZpbGUgaXMgYXV0b21hdGljYWxseSBnZW5lcm
 
 COPY distribution/constraints.txt ${APP_ROOT}/constraints.txt
 COPY distribution/requirements.txt ${APP_ROOT}/requirements.txt
-RUN uv pip install https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9-test/models_dev-1.0.398-2-py3-none-any.whl \
+RUN uv pip install https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9-test/models_dev-1.0.398-2-py3-none-any.whl https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9-test/azure_ai_contentunderstanding-1.1.0-2-py3-none-any.whl \
     && uv pip install --constraint ${APP_ROOT}/constraints.txt -r ${APP_ROOT}/requirements.txt
 
 USER 0

--- a/Dockerfile.konflux.in
+++ b/Dockerfile.konflux.in
@@ -19,7 +19,7 @@ LABEL com.redhat.component="ogx-cpu-rhel9-container" \
 
 COPY distribution/constraints.txt ${APP_ROOT}/constraints.txt
 COPY distribution/requirements.txt ${APP_ROOT}/requirements.txt
-RUN uv pip install https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9-test/models_dev-1.0.398-2-py3-none-any.whl \
+RUN uv pip install https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9-test/models_dev-1.0.398-2-py3-none-any.whl https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9-test/azure_ai_contentunderstanding-1.1.0-2-py3-none-any.whl \
     && uv pip install --constraint ${APP_ROOT}/constraints.txt -r ${APP_ROOT}/requirements.txt
 
 USER 0


### PR DESCRIPTION
## Summary
- Add `azure_ai_contentunderstanding` wheel URL to the pip install line in `Dockerfile.konflux.in` (and generated `Dockerfile.konflux`)
- This package is not available in the EA2 downstream index, so it needs to be installed directly from the wheel URL

## Test plan
- [ ] Verify Konflux build succeeds with the new wheel