### PR TITLE
fix: add pre-download Docling models for offline file processing

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -46,8 +46,9 @@ RUN ${APP_ROOT}/lib/tools/fromager-rpm-check.py --check-rpmdb \
 
 # OGX configuration
 COPY --chmod=755 distribution/install-common.sh ${APP_ROOT}/install-common.sh
+ENV DOCLING_ARTIFACTS_PATH="${APP_ROOT}/.cache/docling/models"
 RUN ${APP_ROOT}/install-common.sh
-ENV TIKTOKEN_CACHE_DIR="${HOME}/.cache/tiktoken"
+ENV TIKTOKEN_CACHE_DIR="${APP_ROOT}/.cache/tiktoken"
 COPY distribution/config.yaml ${APP_ROOT}/config.yaml
 COPY --chmod=755 distribution/entrypoint.sh ${APP_ROOT}/entrypoint.sh
 

--- a/Dockerfile.konflux.in
+++ b/Dockerfile.konflux.in
@@ -38,8 +38,9 @@ RUN ${APP_ROOT}/lib/tools/fromager-rpm-check.py --check-rpmdb \
 
 # OGX configuration
 COPY --chmod=755 distribution/install-common.sh ${APP_ROOT}/install-common.sh
+ENV DOCLING_ARTIFACTS_PATH="${APP_ROOT}/.cache/docling/models"
 RUN ${APP_ROOT}/install-common.sh
-ENV TIKTOKEN_CACHE_DIR="${HOME}/.cache/tiktoken"
+ENV TIKTOKEN_CACHE_DIR="${APP_ROOT}/.cache/tiktoken"
 COPY distribution/config.yaml ${APP_ROOT}/config.yaml
 COPY --chmod=755 distribution/entrypoint.sh ${APP_ROOT}/entrypoint.sh
 


### PR DESCRIPTION
# What does this PR do?
  Adds Konflux Dockerfile support for Docling model pre-downloading, complementing install-common.sh changes from opendatahub-io/ogx-distribution#425

  - Add DOCLING_ARTIFACTS_PATH env var so install-common.sh knows where to store Docling models
  - Fix TIKTOKEN_CACHE_DIR path from ${HOME} to ${APP_ROOT} for consistency with upstream

  The install-common.sh will use DOCLING_ARTIFACTS_PATH to pre-download Docling pipeline models (layout, tableformer, rapidocr, picture_classifier) and the HybridChunker tokenizer
  (all-MiniLM-L6-v2) at build time for offline/disconnected file processing.

  HuggingFace downloads at build time are acceptable for EA2. Hermetic builds (Red Hat-approved model sources) tracked via RHOAIENG-66462 for GA.

## Test Plan
  - [ ] Verify Konflux build succeeds with Docling model downloads