### PR TITLE
fix: bump wheel release to 3.3.1632 for litellm CVE fixes

### DIFF
--- a/konflux/cpu-ubi9.conf
+++ b/konflux/cpu-ubi9.conf
@@ -2,5 +2,5 @@ BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.0-1757673655
 LLAMA_STACK_VERSION=0.0
 WHEEL_RELEASE_PROJECT_ID=71275045
 WHEEL_RELEASE_PACKAGE=llama-stack-wheels
-WHEEL_RELEASE_AARCH64=3.3.1553+llama-stack-cpu-ubi9-aarch64
-WHEEL_RELEASE_X86_64=3.3.1553+llama-stack-cpu-ubi9-x86_64
+WHEEL_RELEASE_AARCH64=3.3.1632+llama-stack-cpu-ubi9-aarch64
+WHEEL_RELEASE_X86_64=3.3.1632+llama-stack-cpu-ubi9-x86_64


### PR DESCRIPTION
# What does this PR do?
Consumes pipeline release 3.3.1632 which includes the AIPCC builder v26.12.2 constraint fix and `litellm>=1.83.7` for CVE-2026-42271, CVE-2026-35029, CVE-2026-35030, and CVE-2026-49468.


