### PR TITLE
fix: install markitdown without [all] extra and add available deps separately

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -27,8 +27,17 @@ LABEL com.ogx.config.config.yaml="IyBUaGlzIGZpbGUgaXMgYXV0b21hdGljYWxseSBnZW5lcm
 
 COPY distribution/constraints.txt ${APP_ROOT}/constraints.txt
 COPY distribution/requirements.txt ${APP_ROOT}/requirements.txt
-RUN uv pip install https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9-test/models_dev-1.0.398-2-py3-none-any.whl https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9-test/azure_ai_contentunderstanding-1.1.0-2-py3-none-any.whl \
-    && uv pip install --constraint ${APP_ROOT}/constraints.txt -r ${APP_ROOT}/requirements.txt
+
+# Not all of the "markitdown[all]" deps available, so install
+# "markitdown" then install the additional deps we have
+# we are missing azure-ai-contentunderstanding, azure-ai-documentintelligence,
+# mammoth, speechrecognition, xlrd and youtube-transcript-api
+RUN sed -i 's/markitdown\[all\]/markitdown/' ${APP_ROOT}/requirements.txt \
+    && uv pip install https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9-test/models_dev-1.0.398-2-py3-none-any.whl \
+    && uv pip install --constraint ${APP_ROOT}/constraints.txt -r ${APP_ROOT}/requirements.txt \
+    && for pkg in azure-identity lxml olefile openpyxl pandas pdfminer-six pdfplumber pydub python-pptx ; do \
+        uv pip install "$pkg" ; \
+    done
 
 USER 0
 # install missing RPMs (online, requires subscription)

--- a/Dockerfile.konflux.in
+++ b/Dockerfile.konflux.in
@@ -19,8 +19,17 @@ LABEL com.redhat.component="ogx-cpu-rhel9-container" \
 
 COPY distribution/constraints.txt ${APP_ROOT}/constraints.txt
 COPY distribution/requirements.txt ${APP_ROOT}/requirements.txt
-RUN uv pip install https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9-test/models_dev-1.0.398-2-py3-none-any.whl https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9-test/azure_ai_contentunderstanding-1.1.0-2-py3-none-any.whl \
-    && uv pip install --constraint ${APP_ROOT}/constraints.txt -r ${APP_ROOT}/requirements.txt
+
+# Not all of the "markitdown[all]" deps available, so install
+# "markitdown" then install the additional deps we have
+# we are missing azure-ai-contentunderstanding, azure-ai-documentintelligence,
+# mammoth, speechrecognition, xlrd and youtube-transcript-api
+RUN sed -i 's/markitdown\[all\]/markitdown/' ${APP_ROOT}/requirements.txt \
+    && uv pip install https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9-test/models_dev-1.0.398-2-py3-none-any.whl \
+    && uv pip install --constraint ${APP_ROOT}/constraints.txt -r ${APP_ROOT}/requirements.txt \
+    && for pkg in azure-identity lxml olefile openpyxl pandas pdfminer-six pdfplumber pydub python-pptx ; do \
+        uv pip install "$pkg" ; \
+    done
 
 USER 0
 # install missing RPMs (online, requires subscription)


### PR DESCRIPTION
## Summary
- Not all `markitdown[all]` dependencies are available in the EA2 base image index
- Changed to install `markitdown` (base) then individually install the extras that are available
- Missing packages: azure-ai-contentunderstanding, azure-ai-documentintelligence, mammoth, speechrecognition, xlrd, youtube-transcript-api

## Test plan
- [ ] Verify container builds successfully
- [ ] Verify markitdown imports and basic functionality works
- [ ] Verify available extras (lxml, openpyxl, pdfminer-six, pdfplumber, etc.) are installed