### PR TITLE
fix: bump wheel release to 3.3.1642 for CVE-2026-34070 and CVE-2026-23490 langchain-core and pyasn1 fixes

### DIFF
--- a/konflux/cpu-ubi9.conf
+++ b/konflux/cpu-ubi9.conf
@@ -2,5 +2,5 @@ BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.0-1757673655
 LLAMA_STACK_VERSION=0.0
 WHEEL_RELEASE_PROJECT_ID=71275045
 WHEEL_RELEASE_PACKAGE=llama-stack-wheels
-WHEEL_RELEASE_AARCH64=3.3.1637+llama-stack-cpu-ubi9-aarch64
-WHEEL_RELEASE_X86_64=3.3.1637+llama-stack-cpu-ubi9-x86_64
+WHEEL_RELEASE_AARCH64=3.3.1642+llama-stack-cpu-ubi9-aarch64
+WHEEL_RELEASE_X86_64=3.3.1642+llama-stack-cpu-ubi9-x86_64


### PR DESCRIPTION
Consumes pipeline release 3.3.1642 which includes langchain-core==0.3.86 (CVE-2026-34070) and pyasn1==0.6.2 (CVE-2026-23490).

Signed-off-by: Matthew F Leader <mleader@redhat.com>