### PR TITLE
fix: bump wheel release to 3.3.1648 for CVE-2026-40192, CVE-2026-44432, CVE-2026-28684

### DIFF
--- a/konflux/cpu-ubi9.conf
+++ b/konflux/cpu-ubi9.conf
@@ -2,5 +2,5 @@ BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.0-1757673655
 LLAMA_STACK_VERSION=0.0
 WHEEL_RELEASE_PROJECT_ID=71275045
 WHEEL_RELEASE_PACKAGE=llama-stack-wheels
-WHEEL_RELEASE_AARCH64=3.3.1642+llama-stack-cpu-ubi9-aarch64
-WHEEL_RELEASE_X86_64=3.3.1642+llama-stack-cpu-ubi9-x86_64
+WHEEL_RELEASE_AARCH64=3.3.1648+llama-stack-cpu-ubi9-aarch64
+WHEEL_RELEASE_X86_64=3.3.1648+llama-stack-cpu-ubi9-x86_64


### PR DESCRIPTION
Bump wheel release from 3.3.1642 to 3.3.1648.

- CVE-2026-40192: pillow 12.1.0 → 12.2.0
- CVE-2026-44432: urllib3 2.6.3 → 2.7.0
- CVE-2026-28684: python-dotenv 1.2.1 → 1.2.2