### PR TITLE
fix: bump wheel release to 3.3.1680 for CVE-2026-34993 CVE-2026-48526 aiohttp pyjwt fixes

### DIFF
--- a/konflux/cpu-ubi9.conf
+++ b/konflux/cpu-ubi9.conf
@@ -2,5 +2,5 @@ BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.0-1757673655
 LLAMA_STACK_VERSION=0.0
 WHEEL_RELEASE_PROJECT_ID=71275045
 WHEEL_RELEASE_PACKAGE=llama-stack-wheels
-WHEEL_RELEASE_AARCH64=3.3.1648+llama-stack-cpu-ubi9-aarch64
-WHEEL_RELEASE_X86_64=3.3.1648+llama-stack-cpu-ubi9-x86_64
+WHEEL_RELEASE_AARCH64=3.3.1680+llama-stack-cpu-ubi9-aarch64
+WHEEL_RELEASE_X86_64=3.3.1680+llama-stack-cpu-ubi9-x86_64


### PR DESCRIPTION
## Summary

Bump wheel release from 3.3.1648 to 3.3.1680 to pick up aiohttp>=3.14.0 and pyjwt>=2.13.0 constraints.

- CVE-2026-34993: aiohttp CookieJar.load() arbitrary code execution
- CVE-2026-48526: PyJWT authentication bypass via forged JWTs