### PR TITLE
fix: bump wheel release to 3.3.1697 for pillow nltk CVE fixes

### DIFF
--- a/konflux/cpu-ubi9.conf
+++ b/konflux/cpu-ubi9.conf
@@ -2,5 +2,5 @@ BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.0-1757673655
 LLAMA_STACK_VERSION=0.0
 WHEEL_RELEASE_PROJECT_ID=71275045
 WHEEL_RELEASE_PACKAGE=llama-stack-wheels
-WHEEL_RELEASE_AARCH64=3.3.1680+llama-stack-cpu-ubi9-aarch64
-WHEEL_RELEASE_X86_64=3.3.1680+llama-stack-cpu-ubi9-x86_64
+WHEEL_RELEASE_AARCH64=3.3.1697+llama-stack-cpu-ubi9-aarch64
+WHEEL_RELEASE_X86_64=3.3.1697+llama-stack-cpu-ubi9-x86_64


### PR DESCRIPTION
## Summary

Bump wheel release from 3.3.1680 to 3.3.1697 to pick up pillow>=12.3.0 and nltk>=3.10.0 constraints.

- CVE-2026-42311: Pillow PSD arbitrary code execution
- CVE-2026-55379: Pillow BDF font DoS
- CVE-2026-55380: Pillow GD image DoS
- CVE-2026-54060: Pillow font file memory allocation DoS
- CVE-2026-54293: NLTK path traversal in nltk.data.load()