### PR TITLE
fix: update base image to cpu:3.3.2-1782914779 for CVE-2026-8643 pip fix

### DIFF
--- a/konflux/cpu-ubi9.conf
+++ b/konflux/cpu-ubi9.conf
@@ -1,4 +1,4 @@
-BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.0-1757673655
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.3.2-1782914779
 LLAMA_STACK_VERSION=0.0
 WHEEL_RELEASE_PROJECT_ID=71275045
 WHEEL_RELEASE_PACKAGE=llama-stack-wheels


### PR DESCRIPTION
CVE-2026-8643: Path traversal via malicious entry point name in pip wheel installation allows arbitrary file overwrite.

Updates `BASE_IMAGE` in `konflux/cpu-ubi9.conf` from `cpu:3.0-1757673655` (pip 25.2) to `cpu:3.3.2-1782914779` (pip 26.1.2).

The AIPCC base image 3.3.2 drops include the pip fix. This change updates the pin so the next Konflux build picks up the fixed base image.