### PR TITLE
feat(security): add SECURITY.md, OpenSSF Scorecard, and cosign signing

### DIFF
--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -377,6 +377,7 @@ jobs:
       OGX_COMMIT_SHA: ${{ github.event.inputs.ogx_commit_sha || 'main' }}
     permissions:
       contents: read
+      id-token: write # for cosign keyless signing
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -406,6 +407,9 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
       - name: Compute branch-specific image tag
         if: github.event_name == 'push'
         run: |
@@ -417,6 +421,7 @@ jobs:
           fi
 
       - name: Publish multi-arch image to Quay.io
+        id: push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -427,6 +432,9 @@ jobs:
           cache-from: |
             type=gha,scope=build-amd64
             type=gha,scope=build-arm64
+
+      - name: Sign container image with cosign
+        run: cosign sign --yes "${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}"
 
       - name: Set Slack notify status
         if: failure()

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,37 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '17 4 * * 1'
+  push:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF results
+        uses: github/codeql-action/upload-sarif@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        with:
+          sarif_file: results.sarif

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it
+responsibly through Red Hat Product Security.
+
+**Email:** [secalert@redhat.com](mailto:secalert@redhat.com)
+
+You can encrypt your report using the Red Hat Product Security PGP key,
+available at: https://access.redhat.com/security/team/contact/
+
+Reports are acknowledged within one business day.
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+## More Information
+
+- [Red Hat Product Security](https://access.redhat.com/security)
+- [Red Hat Coordinated Vulnerability Disclosure Policy](https://access.redhat.com/articles/red-hat-coordinated-vulnerability-disclosure)
+- [Red Hat Vulnerability Management](https://access.redhat.com/security/vulnerability-management)


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` pointing to Red Hat Product Security (`secalert@redhat.com`) for vulnerability disclosure
- Add OpenSSF Scorecard workflow (`.github/workflows/scorecard.yml`) publishing results weekly and on push to `main`
- Add cosign keyless signing of container images in the GitHub publish workflow after Quay push

Closes: [RHAIENG-5627](https://redhat.atlassian.net/browse/RHAIENG-5627)

## Test plan
- [ ] Verify `SECURITY.md` renders correctly and links are valid
- [ ] Verify `scorecard.yml` passes actionlint
- [ ] Verify cosign signing step triggers after a successful publish (will need a merge to `main` or `workflow_dispatch` to exercise)
- [ ] Confirm Konflux/downstream pipelines are unaffected (cosign signing is only in the GitHub workflow path)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)