### PR TITLE
fix: bump wheel release to 3.3.1732 for CVE-2026-42561 python-multipart fix

### DIFF
--- a/konflux/cpu-ubi9.conf
+++ b/konflux/cpu-ubi9.conf
@@ -2,5 +2,5 @@ BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.3.2-1782914779
 LLAMA_STACK_VERSION=0.0
 WHEEL_RELEASE_PROJECT_ID=71275045
 WHEEL_RELEASE_PACKAGE=llama-stack-wheels
-WHEEL_RELEASE_AARCH64=3.3.1697+llama-stack-cpu-ubi9-aarch64
-WHEEL_RELEASE_X86_64=3.3.1697+llama-stack-cpu-ubi9-x86_64
+WHEEL_RELEASE_AARCH64=3.3.1732+llama-stack-cpu-ubi9-aarch64
+WHEEL_RELEASE_X86_64=3.3.1732+llama-stack-cpu-ubi9-x86_64


### PR DESCRIPTION
Bumps the llama-stack wheel release to 3.3.1732 on rhoai-3.3.

Release 3.3.1732 includes python-multipart>=0.0.27, fixing
CVE-2026-42561: python-multipart Denial of Service via excessive
multipart part headers.