### PR TITLE
chore: switch to source install for hermetic build

### DIFF
--- a/build/build.env
+++ b/build/build.env
@@ -3,8 +3,8 @@ OGX_VERSION=v1.2.2+rhaiv.0
 
 # Resolve `ogx` and `ogx-api` packages from git source (true) or from a package index (false)
 # When true, generates the midstream lock file (requirements-lock.txt)
-OGX_INSTALL_FROM_SOURCE=false
+OGX_INSTALL_FROM_SOURCE=true
 
 # Index URL for downstream lock file generation (requirements-lock-konflux.txt)
 # Leave empty to skip downstream lock file generation
-RHAI_INDEX_URL=https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9/simple/
+RHAI_INDEX_URL=


### PR DESCRIPTION
## Summary

- Set `OGX_INSTALL_FROM_SOURCE=true` so `gen_lockfile` resolves ogx from midstream git source
- Clear `RHAI_INDEX_URL` to skip downstream lock file generation (not needed for hermetic build)

This unblocks `update-lockfiles` workflow which currently fails because `ogx-api==v1.2.2` is not on the Pulp index.

After this merges, trigger the `update-lockfiles` workflow on `rhoai-3.5` to regenerate `requirements-lock-konflux.txt` with ogx 1.2.2.