### PR TITLE
fix: pin mcp<2.0.0 in pre-commit (3.4)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,7 @@ repos:
         files: ^distribution/.*$
         additional_dependencies:
           - uv>=0.9.0
+          - mcp>=1.23.0,<2.0.0
 
       - id: doc-gen
         name: Distribution Documentation


### PR DESCRIPTION
## Summary

Pin `mcp>=1.23.0,<2.0.0` in pre-commit `additional_dependencies` to unblock PRs on `rhoai-3.4`.

mcp 2.0.0 (released 2026-07-28) renamed `McpError` to `MCPError`, causing the `pkg-gen` pre-commit hook to crash on any PR targeting this branch.

This is a cherry-pick from opendatahub-io/ogx-distribution#540.

Merge this first, then PR #148 (wheel bump) should pass pre-commit.